### PR TITLE
Resolve #55: Add missing line to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ RUN cd /src && npm install --production --unsafe-perm
 
 ADD . /src
 
+RUN cd /src/modules/hublin-easyrtc-connector && npm install
+
 ADD config/db.json.docker /src/config/db.json
 
 ENV HUBLIN_REDIS_HOST redis

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN cd /src && npm install --production --unsafe-perm
 
 ADD . /src
 
-RUN cd /src/modules/hublin-easyrtc-connector && npm install
+RUN cd /src/modules/hublin-easyrtc-connector && npm install --production
 
 ADD config/db.json.docker /src/config/db.json
 


### PR DESCRIPTION
Install dependencies for hublin-easyrtc-connector when building docker image, which prevents missing dependency errors from causing hublin to fail to start.